### PR TITLE
[Break Glass] Upgrade default SD model to SDXL-Turbo

### DIFF
--- a/deploy/config.yaml.template
+++ b/deploy/config.yaml.template
@@ -11,7 +11,7 @@ APIGW:
 modelsRuntime:
 - name: ${RUNTIME_NAME}
   namespace: "default"
-  modelFilename: "v1-5-pruned-emaonly.safetensors"
+  modelFilename: "sd_xl_turbo_1.0.safetensors"
   dynamicModel: false
   type: ${RUNTIME_TYPE}
   extraValues:
@@ -23,11 +23,7 @@ modelsRuntime:
       provisioner:
         instanceType:
         - "g6.2xlarge"
-        - "g6.xlarge"
-        - "g5.xlarge"
-        - "g4dn.xlarge"
         - "g5.2xlarge"
-        - "g4dn.2xlarge"
         capacityType:
           onDemand: true
           spot: true

--- a/deploy/install-tools.sh
+++ b/deploy/install-tools.sh
@@ -6,8 +6,8 @@ kubectl_version='1.29.0'
 helm_version='3.10.1'
 yq_version='4.30.4'
 s5cmd_version='2.2.2'
-node_version='20.13.1'
-cdk_version='2.133.0'
+node_version='22.12.0'
+cdk_version='2.162.1'
 
 download () {
   url=$1

--- a/deploy/upload-model.sh
+++ b/deploy/upload-model.sh
@@ -6,10 +6,10 @@ MODEL_BUCKET="$1"
 
 AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-$(aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')}
 
-MODEL_URL="https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors?download=true"
-MODEL_NAME="v1-5-pruned-emaonly.safetensors"
+MODEL_URL="https://huggingface.co/stabilityai/sdxl-turbo/resolve/main/sd_xl_turbo_1.0.safetensors"
+MODEL_NAME="sd_xl_turbo_1.0.safetensors"
 
-printf "Transport SD 1.5 base model from hugging face to S3 bucket...\n"
+printf "Transport SDXL-Turbo model from hugging face to S3 bucket...\n"
 curl -L "$MODEL_URL" | aws s3 cp - s3://${MODEL_BUCKET}/Stable-diffusion/${MODEL_NAME}
 
 printf "Model uploaded to s3://${MODEL_BUCKET}/Stable-diffusion/${MODEL_NAME}\n"

--- a/docs/api/v1alpha1.yaml
+++ b/docs/api/v1alpha1.yaml
@@ -39,7 +39,7 @@ paths:
                   sd_model_checkpoint:
                     type: string
                     description: Selected model
-                    example: "v1-5-pruned-emaonly.safetensors"
+                    example: "sd_xl_turbo_1.0.safetensors"
                   output_location:
                     type: string
                     description: Location of output file
@@ -72,11 +72,11 @@ components:
                         type: string
                     sd_model_checkpoint:
                         description: Checkpoint used in the task
-                        example: "v1-5-pruned-emaonly.safetensors"
+                        example: "sd_xl_turbo_1.0.safetensors"
                         type: string
                     id_task:
                         description: Task ID
-                        example: "v1-5-pruned-emaonly.safetensors"
+                        example: "sd_xl_turbo_1.0.safetensors"
                         type: string
                     uid:
                         type: string

--- a/docs/en/async_img_sd_IG.md
+++ b/docs/en/async_img_sd_IG.md
@@ -328,7 +328,7 @@ cd deploy
 This script will:
 
 * Install the necessary runtimes and tools.
-* Create an S3 bucket, download the Stable Diffusion 1.5 foundation model from [HuggingFace](https://huggingface.co/runwayml/stable-diffusion-v1-5){:target="_blank"}, and place it in the bucket.
+* Create an S3 bucket, download the Stable Diffusion XL-Turbo foundation model from [HuggingFace](https://huggingface.co/stabilityai/sdxl-turbo){:target="_blank"}, and place it in the bucket.
 * Create an EBS snapshot containing the SD Web UI image using our provided sample image.
 * Create a Stable Diffusion guidance with the SD Web UI runtime.
 
@@ -679,7 +679,7 @@ The configuration for This guidance is stored in the `config.yaml` file. We prov
     - name: "sdruntime" # Required parameter, the name of the runtime, cannot be the same as other runtimes
       namespace: "default" # Required parameter, the Kubernetes namespace where the runtime is located, not recommended to place in the same namespace as other runtimes
       type: "sdwebui" # Required parameter, the type of this runtime, currently only supports "sdwebui" and "comfyui"
-      modelFilename: "v1-5-pruned-emaonly.safetensors" # (SD Web UI) Name of the model used by this runtime, cannot be the same as other runtimes
+      modelFilename: "sd_xl_turbo_1.0.safetensors" # (SD Web UI) Name of the model used by this runtime, cannot be the same as other runtimes
       dynamicModel: false # (SD Web UI) Whether this runtime allows dynamic model loading
     ```
 
@@ -694,7 +694,7 @@ The configuration for This guidance is stored in the `config.yaml` file. We prov
     - name: "sdruntime"
       namespace: "default"
       type: "sdwebui"
-      modelFilename: "v1-5-pruned-emaonly.safetensors"
+      modelFilename: "sd_xl_turbo_1.0.safetensors"
       dynamicModel: false
       chartRepository: "" # Optional parameter, if you built the Helm Chart, enter the address where the Chart is located. Include the protocol prefix (oci:// or https://)
       chartVersion: "" # Optional parameter, if you built the Helm Chart, enter the version of the Chart
@@ -719,7 +719,7 @@ The configuration for This guidance is stored in the `config.yaml` file. We prov
     - name: "sdruntime"
       namespace: "default"
       type: "sdwebui"
-      modelFilename: "v1-5-pruned-emaonly.safetensors"
+      modelFilename: "sd_xl_turbo_1.0.safetensors"
       extraValues:
         karpenter: # Add the following content
           nodeTemplate:
@@ -840,7 +840,7 @@ APIGW:
 modelsRuntime:
 - name: sdruntime
   namespace: "default"
-  modelFilename: "v1-5-pruned-emaonly.safetensors"
+  modelFilename: "sd_xl_turbo_1.0.safetensors"
   dynamicModel: false
   # chartRepository: "http://example.com/" # If you self-hosted the Helm Chart, uncomment this line and change the value to the address of the Helm Chart (oci:// or http://), otherwise delete this line
   type: sdwebui
@@ -1073,7 +1073,7 @@ v1alpha1
 {
     "alwayson_scripts": {
         "task": "text-to-image", // Required, task type
-        "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors", // Required, base model name
+        "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors", // Required, base model name
         "id_task": "test-t2i", // Required, task ID, used when uploading result images and returning responses
         "save_dir": "outputs" // Required, the prefix (directory name) for the output file in the S3 bucket
     },
@@ -1104,7 +1104,7 @@ v1alpha1
 ```json-doc
 {
   "id_task": "test-t2i",
-  "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+  "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
   "output_location": "s3://outputbucket/output/test-t2i"
 }
 ```
@@ -1116,7 +1116,7 @@ If the corresponding runtime is set to `dynamicModel: true`, you need to add the
 ```json-doc
         "content": {
           "alwayson_scripts": {
-            "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors" //Place the model name here
+            "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors" //Place the model name here
           },
         }
 ```
@@ -1174,7 +1174,7 @@ v1alpha1
         "task": "image-to-image", // Required, task type
         "image_link": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png", // Required, URL of the input image
         "id_task": "test-i2i", // Required, task ID, used when uploading result images and returning responses
-        "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors", // Required, base model name, associated with queue dispatching or model switching
+        "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors", // Required, base model name, associated with queue dispatching or model switching
     },
     // The following are official parameters, use the default values or pass them in directly
     "prompt": "cat wizard, gandalf, lord of the rings, detailed, fantasy, cute, adorable, Pixar, Disney, 8k",
@@ -1203,7 +1203,7 @@ v1alpha1
 ```json-doc
 {
   "id_task": "test-i2i",
-  "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+  "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
   "output_location": "s3://outputbucket/output/test-t2i"
 }
 ```
@@ -1215,7 +1215,7 @@ If the corresponding runtime is set to `dynamicModel: true`, you need to add the
 ```json-doc
         "content": {
           "alwayson_scripts": {
-            "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors" //Place the model name here
+            "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors" //Place the model name here
           },
         }
 ```

--- a/docs/zh/async_img_sd_zh_IG.md
+++ b/docs/zh/async_img_sd_zh_IG.md
@@ -311,7 +311,7 @@ cd deploy
 该脚本将：
 
 * 安装必要的运行时和工具
-* 创建S3存储桶，从[HuggingFace](https://huggingface.co/runwayml/stable-diffusion-v1-5){:target="_blank"} 中下载Stable Diffusion 1.5的基础模型，放置在存储桶中
+* 创建S3存储桶，从[HuggingFace](https://huggingface.co/stabilityai/sdxl-turbo){:target="_blank"} 中下载Stable Diffusion XL-Turbo的基础模型，放置在存储桶中
 * 使用我们提供的示例镜像，创建包含SD Web UI镜像的EBS快照
 * 创建一个含SD Web UI运行时的Stable Diffusion解决方案
 
@@ -663,7 +663,7 @@ cd utils/bottlerocket-images-cache
     - name: "sdruntime" # 必要参数，运行时的名称，不能和其他运行时重名
       namespace: "default" # 必要参数，运行时所在的Kubernetes命名空间，不建议和其他运行时放置在相同的命名空间。
       type: "sdwebui" # 必要参数，该运行时的类型，目前仅支持"sdwebui"和"comfyui"
-      modelFilename: "v1-5-pruned-emaonly.safetensors" # （SD Web UI）该运行时使用的模型名称，不能和其他运行时重复。
+      modelFilename: "sd_xl_turbo_1.0.safetensors" # （SD Web UI）该运行时使用的模型名称，不能和其他运行时重复。
       dynamicModel: false # （SD Web UI）该运行时是否允许动态加载模型。
     ```
 
@@ -678,7 +678,7 @@ cd utils/bottlerocket-images-cache
     - name: "sdruntime"
       namespace: "default"
       type: "sdwebui"
-      modelFilename: "v1-5-pruned-emaonly.safetensors"
+      modelFilename: "sd_xl_turbo_1.0.safetensors"
       dynamicModel: false
       chartRepository: "" # 可选参数，如您构建了Helm Chart，则需要填入Chart所在的地址。需要包含协议前缀 (oci:// 或 https:// )
       chartVersion: "" # 可选参数，如您构建了Helm Chart，则需要填入Chart的版本
@@ -703,7 +703,7 @@ cd utils/bottlerocket-images-cache
     - name: "sdruntime"
       namespace: "default"
       type: "sdwebui"
-      modelFilename: "v1-5-pruned-emaonly.safetensors"
+      modelFilename: "sd_xl_turbo_1.0.safetensors"
       extraValues:
         karpenter: # 添加以下内容
           nodeTemplate:
@@ -825,7 +825,7 @@ APIGW:
 modelsRuntime:
 - name: sdruntime
   namespace: "default"
-  modelFilename: "v1-5-pruned-emaonly.safetensors"
+  modelFilename: "sd_xl_turbo_1.0.safetensors"
   dynamicModel: false
   # chartRepository: "http://example.com/" # 如您自行托管Helm Chart，请去除此行注释，并将值改为Helm Chart的地址（oci://或http://），否则删除此行。
   type: sdwebui
@@ -1061,7 +1061,7 @@ v1alpha1
 {
     "alwayson_scripts": {
         "task": "text-to-image", // 必要，任务类型
-        "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors", // 必要，基础模型名称，关联队列分发或模型切换
+        "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors", // 必要，基础模型名称，关联队列分发或模型切换
         "id_task": "test-t2i", // 必要，任务ID，在上传结果图片和返回响应时会用到
         "save_dir": "outputs" // 必要，输出文件在S3桶中的前缀（即目录名）
     },
@@ -1092,7 +1092,7 @@ v1alpha1
 ```json-doc
 {
   "id_task": "test-t2i",
-  "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+  "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
   "output_location": "s3://outputbucket/output/test-t2i"
 }
 ```
@@ -1104,7 +1104,7 @@ v1alpha1
 ```json-doc
         "content": {
           "alwayson_scripts": {
-            "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors" //此处放入模型名称
+            "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors" //此处放入模型名称
           },
         }
 ```
@@ -1163,7 +1163,7 @@ v1alpha1
         "task": "image-to-image", // 必要，任务类型
         "image_link": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png", // 必要，输入图片的url
         "id_task": "test-i2i", // 必要，任务ID，在上传结果图片和返回响应时会用到
-        "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors", // 必要，基础模型名称，关联队列分发或模型切换
+        "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors", // 必要，基础模型名称，关联队列分发或模型切换
     },
     // 以下皆为官方参数，使用默认值或者直接传入即可
     "prompt": "cat wizard, gandalf, lord of the rings, detailed, fantasy, cute, adorable, Pixar, Disney, 8k",
@@ -1192,7 +1192,7 @@ v1alpha1
 ```json-doc
 {
   "id_task": "test-i2i",
-  "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+  "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
   "output_location": "s3://outputbucket/output/test-t2i"
 }
 ```
@@ -1204,7 +1204,7 @@ v1alpha1
 ```json-doc
         "content": {
           "alwayson_scripts": {
-            "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors" //此处放入模型名称
+            "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors" //此处放入模型名称
           },
         }
 ```

--- a/test/v1alpha1/i2i.json
+++ b/test/v1alpha1/i2i.json
@@ -3,7 +3,7 @@
         "task": "image-to-image",
         "image_link": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/cat.png",
         "id_task": "test-i2i",
-        "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+        "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
         "save_dir": "outputs"
     },
     "prompt": "cat wizard, gandalf, lord of the rings, detailed, fantasy, cute, adorable, Pixar, Disney, 8k",

--- a/test/v1alpha1/t2i.json
+++ b/test/v1alpha1/t2i.json
@@ -1,7 +1,7 @@
 {
     "alwayson_scripts": {
         "task": "text-to-image",
-        "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+        "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
         "id_task": "test-t2i",
         "save_dir": "outputs"
     },

--- a/test/v1alpha1/t2v.json
+++ b/test/v1alpha1/t2v.json
@@ -1,7 +1,7 @@
 {
   "alwayson_scripts": {
     "task": "text-to-image",
-    "sd_model_checkpoint": "v1-5-pruned-emaonly.safetensors",
+    "sd_model_checkpoint": "sd_xl_turbo_1.0.safetensors",
     "id_task": "gif1",
     "uid": "gif1",
     "save_dir": "outputs",

--- a/test/v1alpha2/pipeline.json
+++ b/test/v1alpha2/pipeline.json
@@ -40,7 +40,7 @@
       },
       "4": {
         "inputs": {
-          "ckpt_name": "v1-5-pruned-emaonly.safetensors"
+          "ckpt_name": "sd_xl_turbo_1.0.safetensors"
         },
         "class_type": "CheckpointLoaderSimple",
         "_meta": {


### PR DESCRIPTION
*Description of changes:*
* Since RunwayML has taken out SD 1.5 from Huggingface, replace default model to [SDXL-Turbo](https://huggingface.co/stabilityai/sdxl-turbo) from Stability.ai .
* Remove `g4dn.*` and `*.large` from default instance types. Now default instance types only contains `g5.2xlarge` and `g6.2xlarge` for better performance and availability. 
* Upgrade version of Node.JS and CDK CLI. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
