### PR TITLE
[Break Glass] Change CW agent and Fluent Bit to Cloudwatch Observability

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Get PR author
         id: get-author
         run: |
@@ -30,7 +30,7 @@ jobs:
       - name: Auto-approve if author is able to write and contains only doc change
         id: doc-change
         if: steps.author-permission.outputs.require-result == 'true'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
-CODEOWNERS @aws-solutions-library-samples/maintainers
+* @yubingjiaocn @bnusunny
+CODEOWNERS @aws-solutions-library-samples/maintainers @yubingjiaocn
 /.github/workflows/maintainer_workflows.yml @aws-solutions-library-samples/maintainers
 /.github/solutionid_validator.sh @aws-solutions-library-samples/maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @yubingjiaocn @bnusunny
+* @yubingjiaocn @bnusunny @github-actions
 CODEOWNERS @aws-solutions-library-samples/maintainers @yubingjiaocn
 /.github/workflows/maintainer_workflows.yml @aws-solutions-library-samples/maintainers
 /.github/solutionid_validator.sh @aws-solutions-library-samples/maintainers

--- a/lib/addons/s3CSIDriver.ts
+++ b/lib/addons/s3CSIDriver.ts
@@ -1,5 +1,5 @@
 import * as blueprints from '@aws-quickstart/eks-blueprints';
-import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
+import * as eks from 'aws-cdk-lib/aws-eks';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from "constructs";
 
@@ -12,7 +12,7 @@ export const defaultProps: blueprints.addons.HelmAddOnProps & s3CSIDriverAddOnPr
   name: 's3CSIDriverAddOn',
   namespace: 'kube-system',
   release: 's3-csi-driver-release',
-  version: 'v1.7.0',
+  version: 'v1.10.0',
   repository: 'https://awslabs.github.io/mountpoint-s3-csi-driver',
   s3BucketArn: ''
 }
@@ -31,6 +31,7 @@ export class s3CSIDriverAddOn extends blueprints.addons.HelmAddOn {
     const serviceAccount = cluster.addServiceAccount('s3-csi-driver-sa', {
       name: 's3-csi-driver-sa',
       namespace: this.options.namespace,
+      identityType: eks.IdentityType.POD_IDENTITY
     });
 
     // new IAM policy to grand access to S3 bucket

--- a/lib/dataPlane.ts
+++ b/lib/dataPlane.ts
@@ -100,7 +100,7 @@ export default class DataPlaneStack {
       new blueprints.addons.AwsLoadBalancerControllerAddOn(),
       new blueprints.addons.KarpenterAddOn({ interruptionHandling: true }),
       new blueprints.addons.KedaAddOn(kedaParams),
-      new blueprints.addons.CloudWatchInsights(),
+      new blueprints.addons.CloudWatchInsights(cloudWatchInsightsParams),
       new s3CSIDriverAddOn(s3CSIDriverAddOnParams),
       new SharedComponentAddOn(SharedComponentAddOnParams),
       new EbsThroughputTunerAddOn(EbsThroughputModifyAddOnParams),

--- a/lib/dataPlane.ts
+++ b/lib/dataPlane.ts
@@ -48,49 +48,33 @@ export default class DataPlaneStack {
       irsaRoles: ["CloudWatchFullAccess", "AmazonSQSFullAccess"]
     };
 
-    const CloudWatchLogsWritePolicy = new iam.PolicyStatement({
-      actions: [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:DescribeLogStreams",
-        "logs:PutLogEvents",
-        "logs:GetLogEvents"
-      ],
-      resources: ["*"],
-    })
-
-    const awsForFluentBitParams: blueprints.AwsForFluentBitAddOnProps = {
-      iamPolicies: [CloudWatchLogsWritePolicy],
-      namespace: "amazon-cloudwatch",
-      values: {
-        cloudWatchLogs: {
-          region: cdk.Aws.REGION,
-          logRetentionDays: 7
-        },
-        tolerations: [{
-          "operator": "Exists",
-          "effect": "NoSchedule"
-        }]
-      },
-      createNamespace: true
-    }
-
-    const containerInsightsParams: blueprints.ContainerInsightAddonProps = {
-      values: {
-        adotCollector: {
-          daemonSet: {
-            tolerations: [{
-              "operator": "Exists",
-              "effect": "NoSchedule"
-            }],
-            cwreceivers: {
-              preferFullPodName: "true",
-              addFullPodNameMetricLabel: "true"
+    const cloudWatchInsightsParams: blueprints.CloudWatchInsightsAddOnProps = {
+      configurationValues: {
+        tolerations: [
+          {
+            key: "runtime",
+            operator: "Exists",
+            effect: "NoSchedule"
+          },
+          {
+            key: "nvidia.com/gpu",
+            operator: "Exists",
+            effect: "NoSchedule"
+          }
+        ],
+        containerLogs: {
+          enabled: true,
+          fluentBit: {
+            config: {
+              service: "[SERVICE]\n    Flush        5\n    Grace       30\n    Log_Level   info",
+              extraFiles: {
+                "application-log.conf": "[INPUT]\n    Name             tail\n    Tag              kube.*\n    Path             /var/log/containers/*.log\n    Parser           docker\n    DB               /var/log/flb_kube.db\n    Mem_Buf_Limit    5MB\n    Skip_Long_Lines  On\n    Refresh_Interval 10\n\n[FILTER]\n    Name                kubernetes\n    Match               kube.*\n    Kube_URL            https://kubernetes.default.svc:443\n    Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n    Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token\n    Kube_Tag_Prefix     kube.var.log.containers.\n    Merge_Log           On\n    Merge_Log_Key      log_processed\n    K8S-Logging.Parser On\n    K8S-Logging.Exclude On\n\n[FILTER]\n    Name                grep\n    Match               kube.*\n    Exclude             $kubernetes['namespace_name'] kube-system\n\n[OUTPUT]\n    Name                cloudwatch\n    Match               kube.*\n    region              ${AWS_REGION}\n    log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application\n    log_stream_prefix   ${HOST_NAME}-\n    auto_create_group   true\n    retention_in_days   7"
+              }
             }
           }
         }
       }
-    }
+    };
 
     const SharedComponentAddOnParams: SharedComponentAddOnProps = {
       inputSns: blueprints.getNamedResource("inputSNSTopic"),
@@ -116,12 +100,10 @@ export default class DataPlaneStack {
       new blueprints.addons.AwsLoadBalancerControllerAddOn(),
       new blueprints.addons.KarpenterAddOn({ interruptionHandling: true }),
       new blueprints.addons.KedaAddOn(kedaParams),
-      new blueprints.addons.ContainerInsightsAddOn(containerInsightsParams),
-      new blueprints.addons.AwsForFluentBitAddOn(awsForFluentBitParams),
+      new blueprints.addons.CloudWatchInsights(),
       new s3CSIDriverAddOn(s3CSIDriverAddOnParams),
       new SharedComponentAddOn(SharedComponentAddOnParams),
       new EbsThroughputTunerAddOn(EbsThroughputModifyAddOnParams),
-      new dcgmExporterAddOn({})
     ];
 
 // Generate SD Runtime Addon for runtime

--- a/lib/dataPlane.ts
+++ b/lib/dataPlane.ts
@@ -142,9 +142,9 @@ const MngProps: blueprints.MngClusterProviderProps = {
   minSize: 2,
   maxSize: 2,
   desiredSize: 2,
-  version: eks.KubernetesVersion.V1_29,
-  instanceTypes: [new ec2.InstanceType('m5.large')],
-  amiType: eks.NodegroupAmiType.AL2_X86_64,
+  version: eks.KubernetesVersion.V1_31,
+  instanceTypes: [new ec2.InstanceType('m7g.large')],
+  amiType: eks.NodegroupAmiType.AL2023_ARM_64_STANDARD,
   enableSsmPermissions: true,
   nodeGroupTags: {
     "Name": cdk.Aws.STACK_NAME + "-ClusterComponents",
@@ -154,7 +154,7 @@ const MngProps: blueprints.MngClusterProviderProps = {
 
 // Deploy EKS cluster with all add-ons
 const blueprint = blueprints.EksBlueprint.builder()
-  .version(eks.KubernetesVersion.V1_29)
+  .version(eks.KubernetesVersion.V1_31)
   .addOns(...addOns)
   .resourceProvider(
     blueprints.GlobalResources.Vpc,
@@ -167,7 +167,7 @@ const blueprint = blueprints.EksBlueprint.builder()
   .resourceProvider("s3GWEndpoint", new s3GWEndpointProvider("s3GWEndpoint"))
   .clusterProvider(new blueprints.MngClusterProvider(MngProps))
   .build(scope, id + 'Stack', props);
-
+/*
   // Workaround for permission denied when creating cluster
     const handler = blueprint.node.tryFindChild('@aws-cdk--aws-eks.KubectlProvider')!
       .node.tryFindChild('Handler')! as cdk.aws_lambda.Function
@@ -184,7 +184,7 @@ const blueprint = blueprints.EksBlueprint.builder()
         actions: ["lambda:GetFunctionConfiguration"],
         resources: [handler.functionArn]
       }))
-
+ */
   // Provide static output name for cluster
     const cluster = blueprint.getClusterInfo().cluster
     const clusterNameCfnOutput = cluster.node.findChild('ClusterName') as cdk.CfnOutput;

--- a/lib/resourceProvider/vpc.ts
+++ b/lib/resourceProvider/vpc.ts
@@ -1,0 +1,105 @@
+import { Tags } from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { ISubnet, PrivateSubnet } from 'aws-cdk-lib/aws-ec2';
+import * as blueprints from '@aws-quickstart/eks-blueprints';
+
+/**
+ * Interface for Mapping for fields such as Primary CIDR, Secondary CIDR, Secondary Subnet CIDR.
+ */
+interface VpcProps {
+   primaryCidr?: string,
+   secondaryCidr?: string,
+   secondarySubnetCidrs?: string[]
+}
+
+/**
+ * VPC resource provider
+ */
+export class VpcProvider implements blueprints.ResourceProvider<ec2.IVpc> {
+    readonly vpcId?: string;
+    readonly primaryCidr?: string;
+    readonly secondaryCidr?: string;
+    readonly secondarySubnetCidrs?: string[];
+
+    constructor(vpcId?: string, private vpcProps?: VpcProps) {
+        this.vpcId = vpcId;
+        this.primaryCidr = vpcProps?.primaryCidr;
+        this.secondaryCidr = vpcProps?.secondaryCidr;
+        this.secondarySubnetCidrs = vpcProps?.secondarySubnetCidrs;
+    }
+
+    provide(context: blueprints.ResourceContext): ec2.IVpc {
+        const id = context.scope.node.id;
+
+        let vpc = getVPCFromId(context, id, this.vpcId);
+        if (vpc == null) {
+            // It will automatically divide the provided VPC CIDR range, and create public and private subnets per Availability Zone.
+            // If VPC CIDR range is not provided, uses `10.0.0.0/16` as the range and creates public and private subnets per Availability Zone.
+            // Network routing for the public subnets will be configured to allow outbound access directly via an Internet Gateway.
+            // Network routing for the private subnets will be configured to allow outbound access via a set of resilient NAT Gateways (one per AZ).
+            // Creates Secondary CIDR and Secondary subnets if passed.
+            if (this.primaryCidr) {
+                vpc = new ec2.Vpc(context.scope, id + "-vpc",{
+                    ipAddresses: ec2.IpAddresses.cidr(this.primaryCidr)
+                });
+            }
+            else {
+                vpc = new ec2.Vpc(context.scope, id + "-vpc");
+            }
+        }
+
+
+        if (this.secondaryCidr) {
+            this.createSecondarySubnets(context, id, vpc);
+        }
+
+        return vpc;
+    }
+
+    protected createSecondarySubnets(context: blueprints.ResourceContext, id: string, vpc: ec2.IVpc) {
+        const secondarySubnets: Array<PrivateSubnet> = [];
+        const secondaryCidr = new ec2.CfnVPCCidrBlock(context.scope, id + "-secondaryCidr", {
+            vpcId: vpc.vpcId,
+            cidrBlock: this.secondaryCidr
+        });
+        secondaryCidr.node.addDependency(vpc);
+        if (this.secondarySubnetCidrs) {
+            for (let i = 0; i < vpc.availabilityZones.length; i++) {
+                if (this.secondarySubnetCidrs[i]) {
+                    secondarySubnets[i] = new ec2.PrivateSubnet(context.scope, id + "private-subnet-" + i, {
+                        availabilityZone: vpc.availabilityZones[i],
+                        cidrBlock: this.secondarySubnetCidrs[i],
+                        vpcId: vpc.vpcId
+                    });
+                    secondarySubnets[i].node.addDependency(secondaryCidr);
+                    context.add("secondary-cidr-subnet-" + i, {
+                        provide(_context): ISubnet { return secondarySubnets[i]; }
+                    });
+                }
+            }
+            for (let secondarySubnet of secondarySubnets) {
+                Tags.of(secondarySubnet).add("kubernetes.io/role/internal-elb", "1", { applyToLaunchedInstances: true });
+                Tags.of(secondarySubnet).add("Name", `blueprint-construct-dev-PrivateSubnet-${secondarySubnet}`, { applyToLaunchedInstances: true });
+            }
+        }
+    }
+}
+
+
+
+/*
+** This function will give return vpc based on the ResourceContext and vpcId passed to the cluster.
+ */
+export function getVPCFromId(context: blueprints.ResourceContext, nodeId: string, vpcId?: string) {
+    let vpc = undefined;
+    if (vpcId) {
+        if (vpcId === "default") {
+            console.log(`looking up completely default VPC`);
+            vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { isDefault: true });
+        } else {
+            console.log(`looking up non-default ${vpcId} VPC`);
+            vpc = ec2.Vpc.fromLookup(context.scope, nodeId + "-vpc", { vpcId: vpcId });
+        }
+    }
+    return vpc;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "stable-difussion-on-eks",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stable-difussion-on-eks",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
-        "@aws-quickstart/eks-blueprints": "1.16.2",
+        "@aws-quickstart/eks-blueprints": "1.16.3",
         "@types/lodash": "^4.14.197",
-        "aws-cdk-lib": "2.162.1",
+        "aws-cdk-lib": "2.173.4",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21",
         "yaml": "^2.3.2"
@@ -20,20 +20,20 @@
       },
       "devDependencies": {
         "@types/node": "22.8.6",
-        "aws-cdk": "2.162.1",
+        "aws-cdk": "2.173.4",
         "ts-node": "^10.9.1",
         "typescript": "~5.5.2"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.202",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
-      "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg=="
+      "version": "2.2.228",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.228.tgz",
+      "integrity": "sha512-ToZPI+dEz2BKj//kD2V8oXAvpeBFec5w6tXxIQh/U2iiMLcaUVZw4sxR820jF2GDArZY2D/alVkcSkId0J6rtA=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz",
+      "integrity": "sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/@aws-quickstart/eks-blueprints": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@aws-quickstart/eks-blueprints/-/eks-blueprints-1.16.2.tgz",
-      "integrity": "sha512-u5R3shqq9/4WYm8at/XPvFv05cajHqY2NsiHjkZJQEH//jGp9XQDjL2G1QBMCxde2VnGe3Ng8F+DUwOgzsdzSg==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@aws-quickstart/eks-blueprints/-/eks-blueprints-1.16.3.tgz",
+      "integrity": "sha512-q0i4TlHM1tc6uMWp0PHS/Jt8jZxQoD5gLX0/mTZHlyRKQRjBJsMDea1AmiYz4rc0Ti2xVjF/dVu8g/s611BYxw==",
       "dependencies": {
         "@aws-cdk/lambda-layer-kubectl-v27": "^2.1.0",
         "@aws-cdk/lambda-layer-kubectl-v28": "^2.2.0",
@@ -311,8 +311,8 @@
         "@aws-cdk/lambda-layer-kubectl-v26": "^2.1.0"
       },
       "peerDependencies": {
-        "aws-cdk": "2.162.1",
-        "aws-cdk-lib": "2.162.1"
+        "aws-cdk": "2.173.4",
+        "aws-cdk-lib": "2.173.4"
       }
     },
     "node_modules/@aws-quickstart/eks-blueprints/node_modules/uuid": {
@@ -1645,9 +1645,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.162.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.162.1.tgz",
-      "integrity": "sha512-p9WeiJ7wfiWj0Bpr1HhNdWENf0TxSZN73JtNqvqyaK6SptiLJc+R+ELo0hF3qKT99NWHTCbwWA/JH3BvEXbFxA==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
+      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -1659,9 +1659,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.162.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.162.1.tgz",
-      "integrity": "sha512-XiZLVE5ISNajNNmLye8l5w4EGqm6/d8C8shw63QwxaRVYdHl5e+EAaUEmZJpWc4sYtY/sS+GHOfhoKFLjha2rg==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.4.tgz",
+      "integrity": "sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1676,10 +1676,10 @@
         "mime-types"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-awscli-v1": "^2.2.208",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -1803,9 +1803,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.1",
+      "version": "3.0.3",
       "inBundle": true,
-      "license": "MIT"
+      "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stable-difussion-on-eks",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "bin": {
     "stable-difussion-on-eks": "bin/stable-difussion-on-eks.ts"
   },
@@ -10,14 +10,14 @@
   },
   "devDependencies": {
     "@types/node": "22.8.6",
-    "aws-cdk": "2.162.1",
+    "aws-cdk": "2.173.4",
     "ts-node": "^10.9.1",
     "typescript": "~5.5.2"
   },
   "dependencies": {
-    "@aws-quickstart/eks-blueprints": "1.16.2",
+    "@aws-quickstart/eks-blueprints": "1.16.3",
     "@types/lodash": "^4.14.197",
-    "aws-cdk-lib": "2.162.1",
+    "aws-cdk-lib": "2.173.4",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21",
     "yaml": "^2.3.2"


### PR DESCRIPTION
*Description of changes:*
Per [AWS doc](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html), Container insights add-on are deprecated and Amazon CloudWatch Observability EKS add-on is recommended. This PR change CW agent and Fluent Bit to Amazon CloudWatch Observability EKS add-on to adhere best practice. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
